### PR TITLE
Remove py from dependency list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ more-itertools==8.5.0
 numpy==1.19.2
 packaging==20.4
 pluggy==0.13.1
-py==1.9.0
 pyparsing==2.4.7
 pyquaternion==0.9.9
 pytest==6.1.1


### PR DESCRIPTION
Pretty self explanatory. Removing py from the dependency list (as suggested by Jacob). 

Note: Only changes `requirements.txt`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/state_estimation/15)
<!-- Reviewable:end -->
